### PR TITLE
DRUPSIBLE-118 Added a new variable for injecting ferm input rules. Re…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,3 +107,11 @@ apache2_expires_static_types:
   - 'text/css'
 
 apache2_expires_default: 'access plus 1 day'
+
+apache2_ferm_dependent_rules:
+- type: 'dport_accept'
+  dport: [ "{{ apache2_port | default('http') }}", 'https' ]
+  saddr: '{{ apache2_allow + apache2_group_allow + apache2_host_allow }}'
+  accept_any: True
+  filename: 'apache2_dependency_accept'
+  weight: '20'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,24 +14,4 @@ galaxy_info:
         - trusty
   categories:
     - web
-dependencies: 
-  - role: debops.secret
 
-  - role: debops.ferm
-    ferm_input_list:
-      - type: 'dport_accept'
-        dport: [ "{{ apache2_port | default('http') }}", 'https' ]
-        saddr: '{{ apache2_allow + apache2_group_allow + apache2_host_allow }}'
-        accept_any: True
-        filename: 'apache2_dependency_accept'
-        weight: '20'
-
-  - role: drupsible.newrelic
-    when: "'newrelic-php5' in php5_packages_ontop and apache2_mpm == 'prefork'"
-
-  - role: debops.postfix
-    postfix: [ 'client', 'sender_dependent' ]
-    postfix_relayhost: "[{{ smtp_server }}]:{{ smtp_port }}"
-    postfix_smtp_sasl_password_map: "{ '[{{ smtp_server }}]:{{ smtp_port }}': '{{ smtp_user }}' }"
-    postfix_sender_dependent_relayhost_map: "{ '{{ smtp_user }}': '{{ smtp_server }}:{{ smtp_port }}' }"
-    when: smtp_server is defined and smtp_port is defined and smtp_user is defined

--- a/tasks/apache2.yml
+++ b/tasks/apache2.yml
@@ -25,7 +25,7 @@
   set_fact: 
     uds_available: no
 
-- name: Apache Unix Domain Sockets (USD) are available when 2.4.10+
+- name: Apache Unix Domain Sockets (UDS) are available when 2.4.10+
   when: 'apache2_version is defined and apache2_version.stdout|match("Server version: Apache/2\\.4\\.1.")'
   set_fact: 
     uds_available: yes


### PR DESCRIPTION
…moved hard dependencies. Secret was no longer needed, newrelic and postfix went to the config-no-core playbook.

Signed-off-by: Mariano Barcia mariano.barcia@gmail.com
