### PR TITLE
DRUPSIBLE-253 Added apache2_in_cloud flag to skip the ping allowed check

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,10 @@ apache2_allow: []
 apache2_group_allow: []
 apache2_host_allow: []
 
+# Switch to yes if in a cloud environment where the IPs of the web servers
+# are dynamic (not static/fixed at provision/config time)
+apache2_in_cloud: no
+
 # Inventory group whose servers can ping PHP-FPM status service page
 apache2_ping_group: ''
 

--- a/templates/apache2/vhost-common.conf.j2
+++ b/templates/apache2/vhost-common.conf.j2
@@ -52,9 +52,11 @@
 
   # Ping/status to probe PHP-FPM (status allowed only from load balancers and/or trusted IPs)
   <LocationMatch "{{ apache2_fpm_server_status_path }}$">
-{% for ip in apache2_ping_group_ip_addr_list|default([]) %}
+{% if not apache2_in_cloud|default(False)|bool %}
+{%   for ip in apache2_ping_group_ip_addr_list|default([]) %}
     Require ip {{ ip }}
-{% endfor %}
+{%   endfor %}
+{% endif %}
 {% for ip in apache2_ping_allowed_hosts|default([]) %}
     Require ip {{ ip }}
 {% endfor %}


### PR DESCRIPTION
when deploying to the cloud.

Signed-off-by: Mariano Barcia <mariano.barcia@gmail.com>